### PR TITLE
Feature/transitions-alt-library

### DIFF
--- a/components/theLayout/theLayout.tsx
+++ b/components/theLayout/theLayout.tsx
@@ -1,13 +1,17 @@
+import { useRouter } from 'next/router'
 import Head from 'next/head'
 
 import TheHeader from '../theHeader/theHeader'
 import TheFooter from '../theFooter/theFooter'
+import TheTransitionPage from '../theTransitionPage/theTranstionPage'
 
 type Props = {
   children?: React.ReactNode
 }
 
 const TheLayout: React.FunctionComponent<Props> = ({ children }: Props) => {
+  const router = useRouter()
+
   return (
     <>
       <Head>
@@ -87,7 +91,9 @@ const TheLayout: React.FunctionComponent<Props> = ({ children }: Props) => {
         <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#ffffff" />
       </Head>
       <TheHeader />
-      <main>{children}</main>
+      <TheTransitionPage location={router.pathname}>
+        <main>{children}</main>
+      </TheTransitionPage>
       <TheFooter />
     </>
   )

--- a/components/theTransitionPage/theTranstionPage.tsx
+++ b/components/theTransitionPage/theTranstionPage.tsx
@@ -1,0 +1,55 @@
+import {
+  TransitionGroup,
+  Transition as ReactTransition,
+} from 'react-transition-group'
+
+const timeout = 600
+const ease = 'cubic-bezier(0.43, 0.13, 0.23, 0.96)'
+
+const transitionStyles = {
+  entering: {
+    position: `absolute`,
+    opacity: 0,
+  },
+  entered: {
+    transition: `opacity ${timeout}ms ${ease}`,
+    opacity: 1,
+  },
+  exiting: {
+    transition: `opacity ${timeout}ms ${ease}`,
+    opacity: 0,
+  },
+}
+
+type Props = {
+  children?: React.ReactElement
+  location?: string
+}
+
+const Transition: React.FunctionComponent<Props> = ({
+  children,
+  location,
+}: Props) => {
+  return (
+    <TransitionGroup style={{ position: 'relative' }}>
+      <ReactTransition
+        key={location}
+        timeout={{
+          enter: timeout,
+          exit: timeout,
+        }}
+      >
+        {(status) => (
+          <div
+            style={{
+              ...transitionStyles[status],
+            }}
+          >
+            {children}
+          </div>
+        )}
+      </ReactTransition>
+    </TransitionGroup>
+  )
+}
+export default Transition

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tv-bland",
-  "version": "0.1.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4801,8 +4801,7 @@
     "csstype": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.5.tgz",
-      "integrity": "sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ==",
-      "dev": true
+      "integrity": "sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ=="
     },
     "cyclist": {
       "version": "1.0.1",
@@ -5134,6 +5133,15 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.4.tgz",
       "integrity": "sha512-TvrjBckDy2c6v6RLxPv5QXOnU+SmF9nBII5621Ve5fu6Z/BDrENurBEvlC1f44lKEUVqOpK4w9E5Idc5/EgkLQ==",
       "dev": true
+    },
+    "dom-helpers": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.0.tgz",
+      "integrity": "sha512-Ru5o9+V8CpunKnz5LGgWXkmrH/20cGKwcHwS4m73zIvs54CN9epEmT/HLqFJW3kXpakAFkEdzgy1hzlJe3E4OQ==",
+      "requires": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
     },
     "dom-serializer": {
       "version": "1.0.1",
@@ -11890,6 +11898,17 @@
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz",
       "integrity": "sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg=="
+    },
+    "react-transition-group": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.1.tgz",
+      "integrity": "sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      }
     },
     "read-pkg": {
       "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "postcss-preset-env": "^6.7.0",
     "postcss-simple-vars": "^6.0.1",
     "react": "17.0.1",
-    "react-dom": "17.0.1"
+    "react-dom": "17.0.1",
+    "react-transition-group": "^4.4.1"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.11.6",


### PR DESCRIPTION
### Description
Simple page transitions with alternative library to framer motion, react transition group.

**Note: this experiences the same issue as before with CSS being removed during page transition ref: vercel/next.js#17464, vercel/next.js#18342 and others**